### PR TITLE
LRQA-34296 remove openoffice.cache.enabled from portal-developer.properties

### DIFF
--- a/portal-impl/src/portal-developer.properties
+++ b/portal-impl/src/portal-developer.properties
@@ -14,8 +14,6 @@ combo.check.timestamp=true
 
 minifier.enabled=false
 
-openoffice.cache.enabled=false
-
 com.liferay.portal.servlet.filters.cache.CacheFilter=false
 com.liferay.portal.servlet.filters.etag.ETagFilter=false
 com.liferay.portal.servlet.filters.header.HeaderFilter=false


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-34296